### PR TITLE
Fixed sandbox flag duplicate

### DIFF
--- a/Assets/Xsolla/Payments/Scripts/PaymentsHelper.cs
+++ b/Assets/Xsolla/Payments/Scripts/PaymentsHelper.cs
@@ -41,7 +41,7 @@ namespace Xsolla.Payments
 		/// <seealso cref="BrowserHelper"/>
 		public static void OpenPurchaseByAccessData(string accessData, bool sandbox)
 		{
-			var url = XsollaSettings.IsSandbox
+			var url = sandbox
 				? URL_PAYSTATION_UI_IN_SANDBOX_MODE_BY_ACCESS_DATA
 				: URL_PAYSTATION_UI_BY_ACCESS_DATA;
 			BrowserHelper.Instance.OpenPurchase(url, accessData, sandbox, XsollaSettings.InAppBrowserEnabled);


### PR DESCRIPTION
The `OpenPurchaseByAccessData` utilized purchase mode flag from `sandbox` parameter in one line and from `XsollaSettings.IsSandbox` property in another.

Changed it to use `sandbox` parameter instead of `XsollaSettings.IsSandbox`, same as in `OpenPurchaseByAccessToken`.